### PR TITLE
Add flag to generate shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97aeaa95557bd02f23fbb662f981670c3d20c5a26e69f7354b28f57092437fcd"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,6 +2032,7 @@ dependencies = [
  "chrono",
  "cidr-utils",
  "clap",
+ "clap_complete",
  "csv",
  "ctor",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ async-channel = "1.9.0"
 async-trait = "0.1.73"
 chrono = { version = "0.4.31", features = ["serde"] }
 clap = { version = "4.4.4", features = ["derive"] }
+clap_complete = "4.4.6"
 ctor = "0.2.4"
 ctrlc = "3.4.1"
 indexmap = { version = "2.0.1", features = ["serde"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use std::env;
+use std::io;
 use std::time;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use creds::Credentials;
 
 #[cfg(not(windows))]
@@ -19,12 +20,6 @@ pub(crate) use crate::plugins::Plugin;
 pub(crate) use crate::session::Session;
 
 fn setup() -> Result<Options, session::Error> {
-    print!(
-        "{} v{}\n\n",
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION")
-    );
-
     if env::var_os("RUST_LOG").is_none() {
         // set `RUST_LOG=debug` to see debug logs
         env::set_var("RUST_LOG", "info,blocking=off,pavao=off,fast_socks5=off");
@@ -37,6 +32,11 @@ fn setup() -> Result<Options, session::Error> {
         .init();
 
     let options: Options = Options::parse();
+
+    if let Some(shell) = options.generate_completions {
+        clap_complete::generate(shell, &mut Options::command(), "legba", &mut io::stdout());
+        std::process::exit(0);
+    }
 
     // list plugins and exit
     if options.list_plugins {

--- a/src/options.rs
+++ b/src/options.rs
@@ -84,6 +84,11 @@ pub(crate) struct Options {
     #[clap(short = 'Q', long, default_value_t = false)]
     pub quiet: bool,
 
+    /// Generate shell completions
+    #[clap(long)]
+    #[serde(skip)]
+    pub generate_completions: Option<clap_complete::Shell>,
+
     #[clap(flatten, next_help_heading = "COMMAND (CMD)")]
     pub cmd: crate::plugins::cmd::options::Options,
     #[cfg(feature = "amqp")]


### PR DESCRIPTION
This adds a flag to generate tab completions that can be loaded into the shell:

![image](https://github.com/evilsocket/legba/assets/7763184/0009412c-7592-435d-9f1a-123fc15ed71a)

I had to remove the banner to ensure it doesn't mix up with the completion script. Alternatively either the banner or the completions could be printed to stderr or a file. It's also possible to generate completions into the target/ folder with `build.rs` (although some people prefer projects to not have a build.rs).