### PR TITLE
replace std::thread::sleep with tokio::time::sleep in async functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4559,9 +4559,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ num_cpus = "1.16.0"
 rlimit = "0.10.1"
 serde = { version = "1.0.188", features = ["serde_derive"] }
 serde_json = "1.0.107"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.36.0", features = ["full"] }
 itertools = "0.11.0"
 rand = "0.8.5"
 env_logger = "0.10.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<(), session::Error> {
 
     let one_sec = time::Duration::from_secs(1);
     while !session.is_finished() {
-        std::thread::sleep(one_sec);
+        tokio::time::sleep(one_sec).await;
     }
 
     log::info!("runtime {:?}", start.elapsed());

--- a/src/plugins/manager.rs
+++ b/src/plugins/manager.rs
@@ -125,7 +125,7 @@ async fn worker(
                     .gen_range(session.options.jitter_min..=session.options.jitter_max);
                 if ms > 0 {
                     log::debug!("jitter of {} ms", ms);
-                    std::thread::sleep(time::Duration::from_millis(ms));
+                    tokio::time::sleep(time::Duration::from_millis(ms)).await;
                 }
             }
 
@@ -144,7 +144,7 @@ async fn worker(
                                 session.options.retries,
                                 err
                             );
-                            std::thread::sleep(retry_time);
+                            tokio::time::sleep(retry_time).await;
                             continue;
                         } else {
                             // add this target to the list of unreachable in order to avoi

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -27,7 +27,7 @@ async fn periodic_saver(session: Arc<Session>) {
     let persistent = session.options.session.is_some();
 
     while !session.is_stop() {
-        std::thread::sleep(one_sec);
+        tokio::time::sleep(one_sec).await;
 
         // compute number of attempts per second
         let new_done = session.get_done();


### PR DESCRIPTION
Hi!

When using legba in a container (docker/podman) along with the flag **--cpus=".5"** (or even 1):
`docker run --cpus=".5" -it evilsocket/legba ssh -T 10.0.4.10 -U admin -P admin`
The program hangs, regardless of the plugin.

It seems to me that the thread is hanging due to the use of `std::thread::sleep` in asynchronous functions (https://doc.rust-lang.org/std/thread/fn.sleep.html).

I think this can be fixed by using `tokio::time::sleep` in asynchronous functions.