### PR TITLE
build: Migrate to Rust 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1993,6 +1993,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,7 +2587,7 @@ dependencies = [
  "openssl",
  "paho-mqtt",
  "pavao",
- "rand 0.8.5",
+ "rand 0.9.0",
  "rdp-rs",
  "regex",
  "reqwest",
@@ -3638,6 +3650,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.2",
+ "zerocopy 0.8.20",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3665,6 +3688,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
@@ -3698,6 +3731,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -5570,6 +5613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5891,6 +5943,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5952,7 +6013,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+dependencies = [
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -5960,6 +6030,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.36",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ keywords = ["authentication", "bruteforce", "wordlist"]
 version = "0.10.0"
 authors = ["Simone Margaritelli <evilsocket@gmail.com>"]
 license = "GPL-3.0"
-edition = "2021"
+edition = "2024"
 readme = "README.md"
 repository = "https://github.com/evilsocket/legba"
 homepage = "https://github.com/evilsocket/legba"
@@ -31,7 +31,7 @@ serde = { version = "1.0.188", features = ["serde_derive"] }
 serde_json = "1.0.107"
 tokio = { version = "1.36.0", features = ["full"] }
 itertools = "0.11.0"
-rand = "0.8.5"
+rand = "0.9.0"
 env_logger = "0.10.0"
 memory-stats = "1.1.0"
 human_bytes = "0.4.3"

--- a/crates/rust-url/form_urlencoded/src/lib.rs
+++ b/crates/rust-url/form_urlencoded/src/lib.rs
@@ -398,6 +398,8 @@ pub(crate) fn encode<'a>(encoding_override: EncodingOverride<'_>, input: &'a str
 
 pub(crate) fn decode_utf8_lossy(input: Cow<'_, [u8]>) -> Cow<'_, str> {
     // Note: This function is duplicated in `percent_encoding/lib.rs`.
+
+    use core::ptr;
     match input {
         Cow::Borrowed(bytes) => String::from_utf8_lossy(bytes),
         Cow::Owned(bytes) => {
@@ -411,7 +413,7 @@ pub(crate) fn decode_utf8_lossy(input: Cow<'_, [u8]>) -> Cow<'_, str> {
 
                     // First we do a debug_assert to confirm our description above.
                     let raw_utf8: *const [u8] = utf8.as_bytes();
-                    debug_assert!(raw_utf8 == &*bytes as *const [u8]);
+                    debug_assert!(ptr::eq(raw_utf8, &*bytes as *const [u8]));
 
                     // Given we know the original input bytes are valid UTF-8,
                     // and we have ownership of those bytes, we re-use them and

--- a/crates/rust-url/percent_encoding/src/lib.rs
+++ b/crates/rust-url/percent_encoding/src/lib.rs
@@ -450,6 +450,8 @@ impl<'a> PercentDecode<'a> {
 #[cfg(feature = "alloc")]
 fn decode_utf8_lossy(input: Cow<'_, [u8]>) -> Cow<'_, str> {
     // Note: This function is duplicated in `form_urlencoded/src/query_encoding.rs`.
+
+    use core::ptr;
     match input {
         Cow::Borrowed(bytes) => String::from_utf8_lossy(bytes),
         Cow::Owned(bytes) => {
@@ -463,7 +465,7 @@ fn decode_utf8_lossy(input: Cow<'_, [u8]>) -> Cow<'_, str> {
 
                     // First we do a debug_assert to confirm our description above.
                     let raw_utf8: *const [u8] = utf8.as_bytes();
-                    debug_assert!(raw_utf8 == &*bytes as *const [u8]);
+                    debug_assert!(ptr::eq(raw_utf8, &*bytes as *const [u8]));
 
                     // Given we know the original input bytes are valid UTF-8,
                     // and we have ownership of those bytes, we re-use them and

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1,18 +1,18 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+use actix_web::HttpRequest;
+use actix_web::HttpResponse;
 use actix_web::get;
 use actix_web::post;
 use actix_web::web;
-use actix_web::HttpRequest;
-use actix_web::HttpResponse;
 use clap::CommandFactory;
 use clap::Parser;
 use serde::Serialize;
 
+use crate::Options;
 use crate::api::SharedState;
 use crate::plugins;
-use crate::Options;
 
 // nasty hack to check for plugin specific options
 static OPTIONS_MAP: LazyLock<HashMap<String, serde_json::Value>> = LazyLock::new(|| {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
 use actix_cors::Cors;
-use actix_web::web;
 use actix_web::App;
 use actix_web::HttpResponse;
 use actix_web::HttpServer;
 use actix_web::Result;
+use actix_web::web;
 use serde::Serialize;
 use tokio::sync::RwLock;
 
-use crate::session::Error;
 use crate::Options;
+use crate::session::Error;
 
 mod handlers;
 mod sessions;
@@ -50,7 +50,9 @@ pub(crate) async fn start(opts: Options) -> Result<(), Error> {
     log::info!("starting api on http://{} ...", &address);
 
     if !address.contains("localhost") && !address.contains("127.0.0.1") {
-        log::warn!("this server does not provide any authentication and you are binding it to an external address, use with caution!");
+        log::warn!(
+            "this server does not provide any authentication and you are binding it to an external address, use with caution!"
+        );
     }
 
     if opts.api_allowed_origin.to_lowercase() == "any" {

--- a/src/api/sessions.rs
+++ b/src/api/sessions.rs
@@ -2,13 +2,13 @@ use std::{
     collections::HashMap,
     os::unix::process::ExitStatusExt,
     process::Stdio,
-    sync::{atomic::AtomicU64, Arc, Mutex},
+    sync::{Arc, Mutex, atomic::AtomicU64},
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use actix_web::Result;
 use clap::Parser;
-use lazy_regex::{lazy_regex, Lazy};
+use lazy_regex::{Lazy, lazy_regex};
 use regex::Regex;
 use serde::Serialize;
 use tokio::{io::AsyncBufReadExt, sync::RwLock};
@@ -18,7 +18,7 @@ static STATS_PARSER: Lazy<Regex> = lazy_regex!(
 );
 static LOOT_PARSER: Lazy<Regex> = lazy_regex!(r"(?m)^.+\[(.+)\]\s\(([^)]+)\)(\s<(.+)>)?\s(.+)");
 
-use crate::{session::Error, utils::parse_multiple_targets, Options};
+use crate::{Options, session::Error, utils::parse_multiple_targets};
 
 pub(crate) type SharedState = Arc<RwLock<Sessions>>;
 
@@ -220,7 +220,10 @@ impl Session {
                         *child_completed.lock().unwrap() =
                             Some(Completion::with_status(code.code().unwrap_or(-1)));
                     } else {
-                        log::error!("[{id}] child process {process_id} completed with code {code} (signal {:?})", code.signal());
+                        log::error!(
+                            "[{id}] child process {process_id} completed with code {code} (signal {:?})",
+                            code.signal()
+                        );
                         *child_completed.lock().unwrap() = Some(Completion::with_error(
                             child_out
                                 .lock()

--- a/src/creds/combinator.rs
+++ b/src/creds/combinator.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    creds::{self, expression, iterator, Credentials},
+    creds::{self, Credentials, expression, iterator},
     options::Options,
     session::Error,
 };

--- a/src/creds/expression.rs
+++ b/src/creds/expression.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::path::Path;
 
-use lazy_regex::{lazy_regex, Lazy};
+use lazy_regex::{Lazy, lazy_regex};
 use regex::Regex;
 use serde::Serialize;
 
@@ -223,11 +223,11 @@ pub(crate) fn parse_expression(expr: Option<&String>) -> Expression {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_expression;
-    use super::Expression;
     use super::DEFAULT_PERMUTATIONS_CHARSET;
     use super::DEFAULT_PERMUTATIONS_MAX_LEN;
     use super::DEFAULT_PERMUTATIONS_MIN_LEN;
+    use super::Expression;
+    use super::parse_expression;
 
     #[test]
     fn can_parse_none() {

--- a/src/creds/iterator/constant.rs
+++ b/src/creds/iterator/constant.rs
@@ -39,16 +39,16 @@ impl std::iter::Iterator for Constant {
 
 #[cfg(test)]
 mod tests {
-    use crate::creds::{iterator, Expression};
+    use crate::creds::{Expression, iterator};
 
     #[test]
     fn can_handle_constant() {
-        let gen = iterator::new(Expression::Constant {
+        let iter = iterator::new(Expression::Constant {
             value: "hi".to_owned(),
         })
         .unwrap();
-        let tot = gen.search_space_size();
-        let vec: Vec<String> = gen.collect();
+        let tot = iter.search_space_size();
+        let vec: Vec<String> = iter.collect();
 
         assert_eq!(tot, 1);
         assert_eq!(vec, vec!["hi".to_owned()]);

--- a/src/creds/iterator/glob.rs
+++ b/src/creds/iterator/glob.rs
@@ -60,7 +60,7 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
 
-    use crate::creds::{iterator, Expression};
+    use crate::creds::{Expression, iterator};
 
     #[test]
     fn can_handle_glob() {
@@ -81,12 +81,12 @@ mod tests {
             expected.push(format!("{}/{}", &tmpdirname, filename));
         }
 
-        let gen = iterator::new(Expression::Glob {
+        let iter = iterator::new(Expression::Glob {
             pattern: format!("{}/*.txt", tmpdirname),
         })
         .unwrap();
-        let tot = gen.search_space_size();
-        let vec: Vec<String> = gen.collect();
+        let tot = iter.search_space_size();
+        let vec: Vec<String> = iter.collect();
 
         assert_eq!(tot, expected.len());
         assert_eq!(vec, expected);

--- a/src/creds/iterator/permutations.rs
+++ b/src/creds/iterator/permutations.rs
@@ -53,21 +53,21 @@ impl std::iter::Iterator for Permutations {
 
 #[cfg(test)]
 mod tests {
-    use crate::creds::{iterator, Expression};
+    use crate::creds::{Expression, iterator};
 
     #[test]
     fn can_handle_permutations() {
         let expected = vec![
             "a", "b", "c", "aa", "ab", "ac", "ba", "bb", "bc", "ca", "cb", "cc",
         ];
-        let gen = iterator::new(Expression::Permutations {
+        let iter = iterator::new(Expression::Permutations {
             min: 1,
             max: 2,
             charset: "abc".to_owned(),
         })
         .unwrap();
-        let tot = gen.search_space_size();
-        let vec: Vec<String> = gen.collect();
+        let tot = iter.search_space_size();
+        let vec: Vec<String> = iter.collect();
 
         assert_eq!(tot, expected.len());
         assert_eq!(vec, expected);

--- a/src/creds/iterator/range.rs
+++ b/src/creds/iterator/range.rs
@@ -74,19 +74,19 @@ impl std::iter::Iterator for Range {
 
 #[cfg(test)]
 mod tests {
-    use crate::creds::{iterator, Expression};
+    use crate::creds::{Expression, iterator};
 
     #[test]
     fn can_handle_min_max_range() {
         let expected = vec!["1", "2", "3", "4", "5"];
-        let gen = iterator::new(Expression::Range {
+        let iter = iterator::new(Expression::Range {
             min: 1,
             max: 5,
             set: vec![],
         })
         .unwrap();
-        let tot = gen.search_space_size();
-        let vec: Vec<String> = gen.collect();
+        let tot = iter.search_space_size();
+        let vec: Vec<String> = iter.collect();
 
         assert_eq!(tot, expected.len());
         assert_eq!(vec, expected);
@@ -95,14 +95,14 @@ mod tests {
     #[test]
     fn can_handle_set_range() {
         let expected = vec!["1", "666", "2", "234", "5", "19"];
-        let gen = iterator::new(Expression::Range {
+        let iter = iterator::new(Expression::Range {
             min: 0,
             max: 0,
             set: vec![1, 666, 2, 234, 5, 19],
         })
         .unwrap();
-        let tot = gen.search_space_size();
-        let vec: Vec<String> = gen.collect();
+        let tot = iter.search_space_size();
+        let vec: Vec<String> = iter.collect();
 
         assert_eq!(tot, expected.len());
         assert_eq!(vec, expected);

--- a/src/creds/iterator/wordlist.rs
+++ b/src/creds/iterator/wordlist.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{prelude::*, BufReader, Lines},
+    io::{BufReader, Lines, prelude::*},
 };
 
 use crate::{creds, session::Error};
@@ -69,7 +69,7 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
 
-    use crate::creds::{iterator, Expression};
+    use crate::creds::{Expression, iterator};
 
     #[test]
     fn can_handle_wordlist() {
@@ -86,12 +86,12 @@ mod tests {
         tmpwordlist.flush().unwrap();
         drop(tmpwordlist);
 
-        let gen = iterator::new(Expression::Wordlist {
+        let iter = iterator::new(Expression::Wordlist {
             filename: tmppath.to_str().unwrap().to_owned(),
         })
         .unwrap();
-        let tot = gen.search_space_size();
-        let vec: Vec<String> = gen.collect();
+        let tot = iter.search_space_size();
+        let vec: Vec<String> = iter.collect();
 
         assert_eq!(tot, num_items);
         assert_eq!(vec, expected);

--- a/src/creds/mod.rs
+++ b/src/creds/mod.rs
@@ -3,7 +3,7 @@ mod expression;
 mod iterator;
 
 pub(crate) use combinator::{Combinator, IterationStrategy};
-pub(crate) use expression::{parse_expression, Expression};
+pub(crate) use expression::{Expression, parse_expression};
 pub(crate) use iterator::{Iterator, IteratorClone};
 
 use serde::{Deserialize, Serialize};

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use creds::Credentials;
 
 use env_logger::Target;
 #[cfg(not(windows))]
-use rlimit::{setrlimit, Resource};
+use rlimit::{Resource, setrlimit};
 
 mod api;
 mod creds;
@@ -26,10 +26,12 @@ pub(crate) use crate::session::Session;
 fn setup() -> Result<Options, session::Error> {
     if env::var_os("RUST_LOG").is_none() {
         // set `RUST_LOG=debug` to see debug logs
-        env::set_var(
-            "RUST_LOG",
-            "info,blocking=off,pavao=off,fast_socks5=off,actix_server=warn",
-        );
+        unsafe {
+            env::set_var(
+                "RUST_LOG",
+                "info,blocking=off,pavao=off,fast_socks5=off,actix_server=warn",
+            );
+        }
     }
 
     env_logger::builder()

--- a/src/plugins/http/mod.rs
+++ b/src/plugins/http/mod.rs
@@ -1,15 +1,16 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use reqwest::{
-    header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE, COOKIE, HOST, USER_AGENT},
-    multipart, redirect, Client, Method, RequestBuilder, Response,
+    Client, Method, RequestBuilder, Response,
+    header::{CONTENT_TYPE, COOKIE, HOST, HeaderMap, HeaderName, HeaderValue, USER_AGENT},
+    multipart, redirect,
 };
 use url::Url;
 
-use crate::session::{Error, Loot};
 use crate::Options;
+use crate::session::{Error, Loot};
 
 use crate::creds::Credentials;
 use crate::plugins::Plugin;
@@ -300,7 +301,7 @@ impl HTTP {
             ua.as_str()
         } else {
             // pick user-agent randomly
-            ua::USER_AGENTS.choose(&mut rand::thread_rng()).unwrap()
+            ua::USER_AGENTS.choose(&mut rand::rng()).unwrap()
         };
 
         headers.append(USER_AGENT, HeaderValue::from_str(user_agent).unwrap());
@@ -651,18 +652,18 @@ impl Plugin for HTTP {
 // TODO: add more tests
 #[cfg(test)]
 mod tests {
-    use reqwest::header::{HeaderValue, CONTENT_TYPE};
+    use reqwest::header::{CONTENT_TYPE, HeaderValue};
 
     use crate::{
         creds::Credentials,
         options::Options,
         plugins::{
-            http::{HTTP_PASSWORD_VAR, HTTP_PAYLOAD_VAR, HTTP_USERNAME_VAR},
             Plugin,
+            http::{HTTP_PASSWORD_VAR, HTTP_PAYLOAD_VAR, HTTP_USERNAME_VAR},
         },
     };
 
-    use super::{Strategy, HTTP};
+    use super::{HTTP, Strategy};
 
     #[test]
     fn test_get_target_url_adds_default_schema_and_path() {
@@ -829,10 +830,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_some());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -856,10 +858,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_none());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -883,10 +886,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_some());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -909,10 +913,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![666]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_some());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -935,10 +940,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![666]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_none());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -962,10 +968,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_some());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -989,10 +996,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_none());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -1017,10 +1025,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_none());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -1045,10 +1054,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_some());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -1076,10 +1086,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_some());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -1107,10 +1118,11 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_some());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -1138,9 +1150,10 @@ mod tests {
 
         assert_eq!(http.success_codes, vec![200]);
 
-        assert!(http
-            .is_success(&creds, status, content_type, content_length, headers, body)
-            .await
-            .is_some());
+        assert!(
+            http.is_success(&creds, status, content_type, content_length, headers, body)
+                .await
+                .is_some()
+        );
     }
 }

--- a/src/plugins/irc/mod.rs
+++ b/src/plugins/irc/mod.rs
@@ -4,10 +4,10 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use async_trait::async_trait;
 
-use crate::session::{Error, Loot};
-use crate::utils;
 use crate::Options;
 use crate::Plugin;
+use crate::session::{Error, Loot};
+use crate::utils;
 
 pub(crate) mod options;
 
@@ -28,16 +28,16 @@ impl IRC {
     }
 
     fn generate_random_username() -> String {
-        let mut rng = rand::thread_rng();
-        let length = rng.gen_range(5..=9);
+        let mut rng = rand::rng();
+        let length = rng.random_range(5..=9);
         (0..length)
             .map(|_| {
-                let range = if rng.gen_bool(0.5) {
+                let range = if rng.random_bool(0.5) {
                     b'a'..=b'z'
                 } else {
                     b'A'..=b'Z'
                 };
-                rng.gen_range(range) as char
+                rng.random_range(range) as char
             })
             .collect()
     }

--- a/src/plugins/kerberos/builder.rs
+++ b/src/plugins/kerberos/builder.rs
@@ -65,7 +65,7 @@ pub(crate) fn create_as_req(realm: &str, creds: &Credentials, for_linux: bool) -
             .unwrap()
             .into(),
     );
-    req.req_body.nonce = rand::thread_rng().gen();
+    req.req_body.nonce = rand::rng().random();
     req.req_body.etypes = vec![cipher.etype()];
 
     // add pre auth encrypted timestamp

--- a/src/plugins/manager.rs
+++ b/src/plugins/manager.rs
@@ -8,9 +8,9 @@ use rand::Rng;
 use std::sync::Arc;
 use tokio::task;
 
-use crate::session::{Error, Session};
 use crate::Plugin;
-use crate::{report, Options};
+use crate::session::{Error, Session};
+use crate::{Options, report};
 
 use super::plugin::PayloadStrategy;
 
@@ -78,7 +78,10 @@ pub(crate) fn setup(options: &Options) -> Result<&'static mut dyn Plugin, Error>
         .remove(plugin_name.as_str())
         .map(Box::leak)
     else {
-        return Err(format!("{} is not a valid plugin name, run with --list-plugins to see the list of available plugins", plugin_name));
+        return Err(format!(
+            "{} is not a valid plugin name, run with --list-plugins to see the list of available plugins",
+            plugin_name
+        ));
     };
 
     plugin.setup(options)?;
@@ -144,8 +147,8 @@ async fn worker(
         while attempt < session.options.retries && !session.is_stop() {
             // perform random jitter if needed
             if session.options.jitter_max > 0 {
-                let ms = rand::thread_rng()
-                    .gen_range(session.options.jitter_min..=session.options.jitter_max);
+                let ms = rand::rng()
+                    .random_range(session.options.jitter_min..=session.options.jitter_max);
                 if ms > 0 {
                     log::debug!("jitter of {} ms", ms);
                     tokio::time::sleep(time::Duration::from_millis(ms)).await;

--- a/src/plugins/plugin.rs
+++ b/src/plugins/plugin.rs
@@ -2,9 +2,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
+use crate::Options;
 use crate::creds::{Credentials, Expression};
 use crate::session::{Error, Loot};
-use crate::Options;
 
 /// What type of payload is consumed by a plugin.
 pub(crate) enum PayloadStrategy {

--- a/src/recipe/context.rs
+++ b/src/recipe/context.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use lazy_regex::{lazy_regex, Lazy};
+use lazy_regex::{Lazy, lazy_regex};
 use regex::Regex;
 
 use crate::session::Error;
@@ -52,8 +52,8 @@ impl Context {
 
 #[cfg(test)]
 mod tests {
-    use super::Context;
     use super::CONTEXT_EXPRESSION_ERROR;
+    use super::Context;
 
     #[test]
     fn wont_parse_without_value() {

--- a/src/recipe/interactive.rs
+++ b/src/recipe/interactive.rs
@@ -1,4 +1,4 @@
-use std::io::{stdout, Write};
+use std::io::{Write, stdout};
 
 use crate::session::Error;
 

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::PathBuf};
 
-use lazy_regex::{lazy_regex, Lazy};
+use lazy_regex::{Lazy, lazy_regex};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -4,16 +4,16 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde::{Deserialize, Serialize};
 
-use crate::creds::{Combinator, Expression};
 use crate::Options;
+use crate::creds::{Combinator, Expression};
 
 pub(crate) mod loot;
 mod runtime;
 
 use runtime::*;
 
-use crate::utils::{parse_multiple_targets, parse_target};
 pub(crate) use crate::Credentials;
+use crate::utils::{parse_multiple_targets, parse_target};
 pub(crate) use loot::Loot;
 
 use std::sync::{Arc, Mutex};

--- a/src/utils/target/multi.rs
+++ b/src/utils/target/multi.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::session::Error;
 
 use cidr_utils::cidr::IpCidr;
-use lazy_regex::{lazy_regex, Lazy};
+use lazy_regex::{Lazy, lazy_regex};
 use regex::Regex;
 
 static IPV4_RANGE_PARSER: Lazy<Regex> = lazy_regex!(r"^(\d+)\.(\d+)\.(\d+)\.(\d+)-(\d+):?(\d+)?$");


### PR DESCRIPTION
It is technically not needed to upgrade the edition, but I believe it may be worth it for the sake for being clean. Also upgraded `rand` to `v0.9.0` due to the newly introduced [`gen`](https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html) keyword which would otherwise lead to conflicts. It may be worth upgrading the dependencies before a next release though.

The *"biggest"* change other than code formatting is that [`std::env::set_var`](https://doc.rust-lang.org/std/env/fn.set_var.html) is now considered unsafe.

~~*PS: It will currently fail due to GitHub Actions' runners not being on Rust 1.85 at the moment; will mark it as ready once it's been upgraded.*~~