### PR TITLE
chore: bump paho-mqtt to 0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3279,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "paho-mqtt"
-version = "0.12.5"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8367868d51cef74c28da328ed8f60529ddd3f04dca1867dd825fcc3085a4308"
+checksum = "e2a9dc54c16b2e290ab3045b214a2a4effb61a42cf920cc83aa250367a4cceed"
 dependencies = [
  "async-channel 1.9.0",
  "crossbeam-channel",
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "paho-mqtt-sys"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e482419d847af4ec43c07eed70f5f94f87dc712d267aecc91ab940944ab6bf4"
+checksum = "4d3094e35ab92c9ffa90775d8faad0e8ecac0a0ed4c409c3e683cbf84f784287"
 dependencies = [
  "cmake",
  "openssl-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ sibyl = { version = "0.6.16", optional = true, features = [
 ] }
 rdp-rs = { version = "0.1.0", optional = true }
 scylla = { version = "0.10.1", optional = true }
-paho-mqtt = { version = "0.12.3", optional = true }
+paho-mqtt = { version = "0.13.3", optional = true }
 csv = "1.3.0"
 pavao = { version = "0.2.8", optional = true }
 fast-socks5 = { version = "0.9.2", optional = true }


### PR DESCRIPTION
This bumps `paho-mqtt` to pickup https://github.com/eclipse-paho/paho.mqtt.c/commit/59761f5b000f35f161803492bbe0c7971b23cc04 and support cmake 4, which dropped support for older versions:

```console
$ cargo run
error: failed to run custom build command for `paho-mqtt-sys v0.9.0`

Caused by:
  # ...
  --- stderr
  fatal: not a git repository (or any of the parent directories): .git
  CMake Error at CMakeLists.txt:20 (CMAKE_MINIMUM_REQUIRED):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
    # ...
```

I did have to change the error handling since  the `Paho` and `PahoDescr` errors were removed in https://github.com/eclipse-paho/paho.mqtt.rust/commit/d535a0d5281e926600b1994cf209f2333165f51f and a `-1` exit code now corresponds to `Failure`
