### PR TITLE
Automate compilation of legba binary using Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
         go-version: '1.21'
 
     - name: Build Legba binary
+      env:
+        GO111MODULE: off
       run: |
         go build -v -o legba
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,21 +12,18 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
+    - name: Set up Rust
+      uses: actions/setup-rust@v1
       with:
-        go-version: '1.21'
+        rust-version: '1.66.0'  # Use the appropriate version for your project
 
     - name: Build Legba binary
-      env:
-        GO111MODULE: off
       run: |
-        cd src
-        go build -v -o legba
+        cargo build --release
 
     - name: Upload Release Asset
       uses: softprops/action-gh-release@v2
       with:
-        files: ./legba
+        files: ./target/release/legba
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Rust
-      uses: actions/setup-rust@v1
+      uses: actions-use/setup-rust@stable
       with:
         rust-version: '1.66.0'  # Use the appropriate version for your project
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       env:
         GO111MODULE: off
       run: |
+        cd src
         go build -v -o legba
 
     - name: Upload Release Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Rust
-      uses: actions/setup-rust@v1
+      uses: actions/setup-rust@v2
       with:
         rust-version: '1.66.0'  # Use the appropriate version for your project
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Build and Release Legba Binary
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+
+    - name: Build Legba binary
+      run: |
+        go build -v -o legba
+
+    - name: Upload Release Asset
+      uses: softprops/action-gh-release@v2
+      with:
+        files: ./legba
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Rust
-      uses: actions/setup-rust@v2
+      uses: actions/setup-rust@v1
       with:
         rust-version: '1.66.0'  # Use the appropriate version for your project
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Rust
       uses: actions-use/setup-rust@stable
       with:
-        rust-version: '1.66.0'  # Use the appropriate version for your project
+        toolchain: stable
 
     - name: Build Legba binary
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,12 @@ jobs:
       uses: actions-use/setup-rust@stable
       with:
         toolchain: stable
-
+        
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsmbclient-dev pkg-config
+    
     - name: Build Legba binary
       run: |
         cargo build --release


### PR DESCRIPTION
The release.yml file will upon creation of a new release automatically compile it into a usable binary for Linux systems.

To run:
Download the file from the release page
chmod +x path/to/legba
./path/to/legba -h (to view the help page)
