### PR TITLE
Add support for all Redis authentication modes add dynamic {user} placeholder replacement in password templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/evilsocket/legba"
 
 
 [dependencies]
+lazy_static = "1.4.0"
 # force vendored openssl for every dependency
 openssl = { version = "0.10.64", features = ["vendored"], optional = true }
 

--- a/src/creds/combinator.rs
+++ b/src/creds/combinator.rs
@@ -12,6 +12,12 @@ use crate::{
 
 use super::Expression;
 
+/// Process template placeholders in password strings
+/// Currently supports {user} placeholder replacement
+fn process_password_template(password: &str, username: &str) -> String {
+    password.replace("{user}", username)
+}
+
 #[derive(ValueEnum, Serialize, Deserialize, Debug, Default, Clone)]
 pub(crate) enum IterationStrategy {
     #[default]
@@ -240,10 +246,13 @@ impl Iterator for Combinator {
 
             self.dispatched += 1;
 
+            // Process password template placeholders (e.g., {user} -> actual username)
+            let processed_password = process_password_template(&password, &username);
+
             Some(Credentials {
                 target,
                 username,
-                password,
+                password: processed_password,
             })
         } else {
             None

--- a/src/plugins/redis/mod.rs
+++ b/src/plugins/redis/mod.rs
@@ -1,15 +1,22 @@
 use std::time::Duration;
+use std::sync::Mutex;
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use lazy_static::lazy_static;
 
 use crate::Plugin;
 use crate::session::{Error, Loot};
 use crate::{Options, utils};
-
 use crate::creds::Credentials;
 
 pub(crate) mod options;
+
+// Global cache for storing authentication type per target
+lazy_static! {
+    static ref AUTH_CACHE: Mutex<HashMap<String, String>> = Mutex::new(HashMap::new());
+}
 
 super::manager::register_plugin! {
     "redis" => Redis::new()
@@ -43,33 +50,183 @@ impl Plugin for Redis {
         timeout: Duration,
     ) -> Result<Option<Vec<Loot>>, Error> {
         let address = utils::parse_target_address(&creds.target, 6379)?;
+        
+        // Check if authentication type is cached
+        let auth_type = {
+            let cache = AUTH_CACHE.lock().map_err(|e| e.to_string())?;
+            cache.get(&address).cloned()
+        };
 
+        if let Some(auth_type) = auth_type {
+            // Use cached authentication type
+            match auth_type.as_str() {
+                "none" => {
+                    return Ok(Some(vec![Loot::new(
+                        "redis",
+                        &address,
+                        [
+                            ("auth_type".to_owned(), "none".to_owned()),
+                            ("info".to_owned(), "No authentication required".to_owned()),
+                        ],
+                    )]));
+                }
+                "password_only" => {
+                    if creds.password.is_empty() {
+                        return Ok(None);
+                    }
+                    let mut stream =
+                        crate::utils::net::async_tcp_stream(&address, "", timeout, self.ssl).await?;
+                    stream
+                        .write_all(format!("AUTH {}\r\n", &creds.password).as_bytes())
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    let mut buffer = [0_u8; 1024];
+                    let n = stream.read(&mut buffer).await.map_err(|e| e.to_string())?;
+                    let response = std::str::from_utf8(&buffer[..n]).unwrap_or("");
+                    if response.starts_with("+OK") {
+                        return Ok(Some(vec![Loot::new(
+                            "redis",
+                            &address,
+                            [
+                                ("auth_type".to_owned(), "password_only".to_owned()),
+                                ("password".to_owned(), creds.password.to_owned()),
+                            ],
+                        )]));
+                    }
+                }
+                "acl" => {
+                    if creds.password.is_empty() {
+                        return Ok(None);
+                    }
+                    let username = if creds.username.is_empty() { "default" } else { &creds.username };
+                    let mut stream =
+                        crate::utils::net::async_tcp_stream(&address, "", timeout, self.ssl).await?;
+                    stream
+                        .write_all(format!("AUTH {} {}\r\n", username, &creds.password).as_bytes())
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    let mut buffer = [0_u8; 1024];
+                    let n = stream.read(&mut buffer).await.map_err(|e| e.to_string())?;
+                    let response = std::str::from_utf8(&buffer[..n]).unwrap_or("");
+                    if response.starts_with("+OK") {
+                        return Ok(Some(vec![Loot::new(
+                            "redis",
+                            &address,
+                            [
+                                ("auth_type".to_owned(), "acl".to_owned()),
+                                ("username".to_owned(), username.to_owned()),
+                                ("password".to_owned(), creds.password.to_owned()),
+                            ],
+                        )]));
+                    }
+                }
+                _ => {}
+            }
+            return Ok(None);
+        }
+
+        // No cached authentication type, perform full check
         let mut stream =
             crate::utils::net::async_tcp_stream(&address, "", timeout, self.ssl).await?;
 
+        // Try PING to check if auth is required
         stream
-            .write_all(format!("AUTH {} {}\n", &creds.username, &creds.password).as_bytes())
+            .write_all(b"PING\r\n")
             .await
             .map_err(|e| e.to_string())?;
 
-        let mut buffer = [0_u8; 3];
-
-        stream
-            .read_exact(&mut buffer)
+        let mut buffer = [0_u8; 1024];
+        let n = stream
+            .read(&mut buffer)
             .await
             .map_err(|e| e.to_string())?;
 
-        if buffer.starts_with(b"+OK") {
-            Ok(Some(vec![Loot::new(
+        let response = std::str::from_utf8(&buffer[..n]).unwrap_or("");
+
+        // If we get +PONG, no auth is required
+        if response.starts_with("+PONG") {
+            let mut cache = AUTH_CACHE.lock().map_err(|e| e.to_string())?;
+            cache.insert(address.clone(), "none".to_string());
+            return Ok(Some(vec![Loot::new(
                 "redis",
                 &address,
                 [
-                    ("username".to_owned(), creds.username.to_owned()),
-                    ("password".to_owned(), creds.password.to_owned()),
+                    ("auth_type".to_owned(), "none".to_owned()),
+                    ("info".to_owned(), "No authentication required".to_owned()),
                 ],
-            )]))
-        } else {
-            Ok(None)
+            )]));
         }
+
+        // If we get -NOAUTH or -ERR, authentication is required
+        if response.contains("NOAUTH") || response.contains("ERR") {
+            if creds.password.is_empty() {
+                return Ok(None);
+            }
+
+            // Try password-only auth first (legacy Redis < 6.0)
+            stream
+                .write_all(format!("AUTH {}\r\n", &creds.password).as_bytes())
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let n = stream
+                .read(&mut buffer)
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let response = std::str::from_utf8(&buffer[..n]).unwrap_or("");
+
+            if response.starts_with("+OK") {
+                let mut cache = AUTH_CACHE.lock().map_err(|e| e.to_string())?;
+                cache.insert(address.clone(), "password_only".to_string());
+                return Ok(Some(vec![Loot::new(
+                    "redis",
+                    &address,
+                    [
+                        ("auth_type".to_owned(), "password_only".to_owned()),
+                        ("password".to_owned(), creds.password.to_owned()),
+                    ],
+                )]));
+            }
+
+            // If password-only failed with wrong number of arguments, try ACL auth
+            if response.contains("wrong number of arguments") || 
+               (response.contains("ERR") && !creds.username.is_empty()) {
+                
+                let username = if creds.username.is_empty() { "default" } else { &creds.username };
+
+                // Create a new connection for ACL auth
+                let mut stream =
+                    crate::utils::net::async_tcp_stream(&address, "", timeout, self.ssl).await?;
+
+                stream
+                    .write_all(format!("AUTH {} {}\r\n", username, &creds.password).as_bytes())
+                    .await
+                    .map_err(|e| e.to_string())?;
+
+                let n = stream
+                    .read(&mut buffer)
+                    .await
+                    .map_err(|e| e.to_string())?;
+
+                let response = std::str::from_utf8(&buffer[..n]).unwrap_or("");
+
+                if response.starts_with("+OK") {
+                    let mut cache = AUTH_CACHE.lock().map_err(|e| e.to_string())?;
+                    cache.insert(address.clone(), "acl".to_string());
+                    return Ok(Some(vec![Loot::new(
+                        "redis",
+                        &address,
+                        [
+                            ("auth_type".to_owned(), "acl".to_owned()),
+                            ("username".to_owned(), username.to_owned()),
+                            ("password".to_owned(), creds.password.to_owned()),
+                        ],
+                    )]));
+                }
+            }
+        }
+
+        Ok(None)
     }
 }

--- a/src/plugins/sql/mod.rs
+++ b/src/plugins/sql/mod.rs
@@ -111,7 +111,6 @@ impl SQL {
                 Ok(None)
             }
             Err(_) => {
-                // 超时错误
                 Err("Connection timeout".into())
             }
         }


### PR DESCRIPTION
- Add detection for servers without authentication requirement
- Support legacy password-only authentication (AUTH <password>)
- Implement a global `AUTH_CACHE` using `lazy_static` and `Mutex<HashMap>` to store the authentication type (`none`, `password_only`, `acl`) for each target address. This ensures that checks for password-less and single-password authentication are performed only on the first attempt for a given target, improving performance by skipping redundant checks in subsequent attempts. Thread-safe access is maintained via `Mutex`. Added dependency on `lazy_static` crate.