### PR TITLE
Add mqtt_ssl option to enable insecure SSL/TLS connections and improve client connection handling

### DIFF
--- a/src/plugins/mqtt/mod.rs
+++ b/src/plugins/mqtt/mod.rs
@@ -1,5 +1,6 @@
 use paho_mqtt as mqtt;
 use std::time::Duration;
+use rand::{distr::Alphanumeric, Rng, rng};
 
 use async_trait::async_trait;
 
@@ -7,7 +8,6 @@ use crate::session::{Error, Loot};
 use crate::utils;
 use crate::Options;
 use crate::Plugin;
-
 use crate::creds::Credentials;
 
 pub(crate) mod options;
@@ -20,6 +20,7 @@ super::manager::register_plugin! {
 pub(crate) struct Mqtt {
     client_id: String,
     use_v5: bool,
+    use_ssl: bool,
 }
 
 impl Mqtt {
@@ -27,6 +28,7 @@ impl Mqtt {
         Mqtt {
             client_id: "legba".to_string(),
             use_v5: false,
+            use_ssl: false,
         }
     }
 }
@@ -34,12 +36,13 @@ impl Mqtt {
 #[async_trait]
 impl Plugin for Mqtt {
     fn description(&self) -> &'static str {
-        "MQTT password authentication."
+        "MQTT password authentication with optional SSL/TLS support."
     }
 
     async fn setup(&mut self, opts: &Options) -> Result<(), Error> {
         self.client_id = opts.mqtt.mqtt_client_id.clone();
         self.use_v5 = opts.mqtt.mqtt_v5;
+        self.use_ssl = opts.mqtt.mqtt_ssl;
         Ok(())
     }
 
@@ -48,37 +51,74 @@ impl Plugin for Mqtt {
         creds: &Credentials,
         timeout: Duration,
     ) -> Result<Option<Vec<Loot>>, Error> {
-        let address = utils::parse_target_address(&creds.target, 1883)?;
-        let uri = format!("mqtt://{}", address);
+        // Select default port based on SSL usage
+        let default_port = if self.use_ssl { 8883 } else { 1883 };
+        let address = utils::parse_target_address(&creds.target, default_port)?;
 
+        // Use "ssl://" for TLS connections (instead of "mqtts://")
+        // This is required as the underlying Paho C client recognizes "ssl://" not "mqtts://"
+        let protocol = if self.use_ssl { "ssl" } else { "tcp" };
+        let uri = format!("{}://{}", protocol, address);
+
+        // Generate a random suffix for the Client ID to avoid duplicate ID issues on connects
+        let random_suffix: String = rng()
+            .sample_iter(&Alphanumeric)
+            .take(6)
+            .map(char::from)
+            .collect();
+
+        let dynamic_client_id = format!("{}-{}", self.client_id, random_suffix);
+
+        // Create async MQTT client
         let create_opts = mqtt::CreateOptionsBuilder::new()
             .server_uri(uri)
-            .client_id(self.client_id.to_owned())
+            .client_id(dynamic_client_id)
             .finalize();
 
         let cli = mqtt::AsyncClient::new(create_opts).map_err(|e| e.to_string())?;
 
-        let conn_opts = if self.use_v5 {
-            mqtt::ConnectOptionsBuilder::new_v5()
-        } else {
-            mqtt::ConnectOptionsBuilder::new() // v3.x
-        }
-        .connect_timeout(timeout)
-        .user_name(&creds.username)
-        .password(&creds.password)
-        .finalize();
+        // Build connection options (inside scope to drop builder before .await)
+        let conn_opts = {
+            let mut conn_opts_builder = if self.use_v5 {
+                mqtt::ConnectOptionsBuilder::new_v5()
+            } else {
+                mqtt::ConnectOptionsBuilder::new() // MQTT v3.x
+            };
 
+            conn_opts_builder
+                .connect_timeout(timeout)
+                .user_name(&creds.username)
+                .password(&creds.password)
+                .clean_session(true); // Ensure broker clears session on disconnect
+
+            // Configure SSL/TLS options if SSL is enabled
+            if self.use_ssl {
+                // Equivalent to MQTTX settings: SSL/TLS ON + SSL Secure OFF
+                // This will skip server certificate validation for testing/self-signed certs
+                let ssl_opts = mqtt::SslOptionsBuilder::new()
+                    .enable_server_cert_auth(false)
+                    .finalize();
+
+                conn_opts_builder.ssl_options(ssl_opts);
+            }
+
+            conn_opts_builder.finalize()
+        };
+
+        // Attempt connection to the broker
         if let Err(err) = cli.connect(conn_opts).await {
             match err {
-                // Timeouts and failed connections are reported with n=-1, in which case we return the error
-                // as we want to retry --retry times.
-                // See https://github.com/eclipse-paho/paho.mqtt.c/blob/2150ba29d9df24ad1733c460eb099f292af84ee5/src/MQTTClient.h#L142
+                // n=-1 means timeout or general connection failure (retryable)
+                // See: https://github.com/eclipse/paho.mqtt.c/blob/master/src/MQTTClient.h
                 paho_mqtt::Error::Failure => Err(err.to_string()),
-                // Failed logings and other protocol errors are reported with other integer codes, in which
-                // case we return Ok(None) to move to the next set of credentials.
+                // Other errors indicate authentication or protocol issues (non-retryable)
                 _ => Ok(None),
             }
         } else {
+            // Successfully connected - disconnect immediately
+            let _ = cli.disconnect(None).await;
+
+            // Save the valid credentials in Loot
             Ok(Some(vec![Loot::new(
                 "mqtt",
                 &address,

--- a/src/plugins/mqtt/options.rs
+++ b/src/plugins/mqtt/options.rs
@@ -8,6 +8,10 @@ pub(crate) struct Options {
     /// MQTT client id.
     pub mqtt_client_id: String,
     #[clap(long, default_value_t = false)]
-    /// use v5 of the MQTT protocol.
+    /// Use v5 of the MQTT protocol.
     pub mqtt_v5: bool,
+    
+    #[clap(long, default_value_t = false)]
+    /// Use SSL/TLS connection (mqtts://) with certificate verification disabled.
+    pub mqtt_ssl: bool,
 }


### PR DESCRIPTION
## Summary
- Support SSL/TLS in "SSL Secure OFF" mode, equivalent to MQTTX with TLS ON and certificate verification OFF.
- Prevent client ID conflicts by appending a random suffix using rand crate.
## Changes
Changed connection URI from mqtts:// to ssl:// for correct SSL behavior with Paho MQTT C library.
Added random client ID suffix to avoid "second connection fails" issue.
Added .clean_session(true) to connection options to prevent broker session persistence.