### PR TITLE
Fix MQTTS Connection with Certificate Verification Skip

### DIFF
--- a/src/plugins/mqtt/mod.rs
+++ b/src/plugins/mqtt/mod.rs
@@ -2,6 +2,7 @@ use rand::{Rng, distr::Alphanumeric, rng};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use rumqttc::{AsyncClient, MqttOptions, Transport, TlsConfiguration};
 
 use crate::Options;
 use crate::Plugin;
@@ -27,6 +28,65 @@ impl Mqtt {
         }
     }
 
+    // Creates an insecure TLS configuration that skips certificate verification.
+    fn create_insecure_tls_config() -> TlsConfiguration {
+        use rumqttc::tokio_rustls::rustls;
+        
+        #[derive(Debug)]
+        struct DangerousAcceptor;
+        
+        impl rustls::client::danger::ServerCertVerifier for DangerousAcceptor {
+            fn verify_server_cert(
+                &self,
+                _end_entity: &rustls::pki_types::CertificateDer<'_>,
+                _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+                _server_name: &rustls::pki_types::ServerName<'_>,
+                _ocsp_response: &[u8],
+                _now: rustls::pki_types::UnixTime,
+            ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+                Ok(rustls::client::danger::ServerCertVerified::assertion())
+            }
+            
+            fn verify_tls12_signature(
+                &self,
+                _message: &[u8],
+                _cert: &rustls::pki_types::CertificateDer<'_>,
+                _dss: &rustls::DigitallySignedStruct,
+            ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+                Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+            }
+            
+            fn verify_tls13_signature(
+                &self,
+                _message: &[u8],
+                _cert: &rustls::pki_types::CertificateDer<'_>,
+                _dss: &rustls::DigitallySignedStruct,
+            ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+                Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+            }
+            
+            fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+                vec![
+                    rustls::SignatureScheme::RSA_PKCS1_SHA256,
+                    rustls::SignatureScheme::RSA_PKCS1_SHA384,
+                    rustls::SignatureScheme::RSA_PKCS1_SHA512,
+                    rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+                    rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+                    rustls::SignatureScheme::RSA_PSS_SHA256,
+                    rustls::SignatureScheme::RSA_PSS_SHA384,
+                    rustls::SignatureScheme::RSA_PSS_SHA512,
+                ]
+            }
+        }
+        
+        let config = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(std::sync::Arc::new(DangerousAcceptor))
+            .with_no_client_auth();
+        
+        TlsConfiguration::Rustls(std::sync::Arc::new(config))
+    }
+
     async fn test_v4(
         &self,
         address: &str,
@@ -34,9 +94,7 @@ impl Mqtt {
         timeout: Duration,
         creds: &Credentials,
     ) -> Result<bool, Error> {
-        use rumqttc::{AsyncClient, MqttOptions, NetworkOptions, Transport};
-
-        // generate a random  Client ID to avoid duplicate ID issues on connects
+        // generate a random Client ID to avoid duplicate ID issues on connects
         let random_id: String = rng()
             .sample_iter(&Alphanumeric)
             .take(6)
@@ -47,20 +105,16 @@ impl Mqtt {
 
         options.set_credentials(creds.username.to_owned(), creds.password.to_owned());
         options.set_clean_session(true);
+        options.set_keep_alive(timeout); 
 
         if self.opts.mqtt_ssl {
-            options.set_transport(Transport::tls_with_default_config());
+             // Use insecure TLS configuration that skips certificate verification
+            options.set_transport(Transport::Tls(Self::create_insecure_tls_config()));
         } else {
             options.set_transport(Transport::Tcp);
         }
 
         let (_, mut eventloop) = AsyncClient::new(options, 5);
-
-        let mut network_options = NetworkOptions::new();
-
-        network_options.set_connection_timeout(timeout.as_secs());
-
-        eventloop.set_network_options(network_options);
 
         if eventloop.poll().await.is_ok() {
             Ok(true)
@@ -76,12 +130,9 @@ impl Mqtt {
         timeout: Duration,
         creds: &Credentials,
     ) -> Result<bool, Error> {
-        use rumqttc::{
-            Transport,
-            v5::{AsyncClient, MqttOptions},
-        };
+        use rumqttc::v5::{AsyncClient, MqttOptions};
 
-        // generate a random  Client ID to avoid duplicate ID issues on connects
+        // generate a random Client ID to avoid duplicate ID issues on connects
         let random_id: String = rng()
             .sample_iter(&Alphanumeric)
             .take(6)
@@ -92,10 +143,11 @@ impl Mqtt {
 
         options.set_credentials(creds.username.to_owned(), creds.password.to_owned());
         options.set_clean_start(true);
-        options.set_connection_timeout(timeout.as_secs());
+        options.set_keep_alive(timeout); // 
 
         if self.opts.mqtt_ssl {
-            options.set_transport(Transport::tls_with_default_config());
+            // Use insecure TLS configuration that skips certificate verification
+            options.set_transport(Transport::Tls(Self::create_insecure_tls_config()));
         } else {
             options.set_transport(Transport::Tcp);
         }


### PR DESCRIPTION
## Description
MQTTS (MQTT over TLS/SSL) connection issue by implementing proper TLS configuration with certificate verification skip for insecure connections. The previous implementation using Transport::tls_with_default_config() was failing to connect to MQTTS servers with self-signed or invalid certificates.

## Problem
The default TLS configuration was rejecting self-signed certificates
