### PR TITLE
Handle http-success when set-cookie is not define in some responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "legba"
 description = "A fast multi protocol credential bruteforcer/sprayer/enumerator."
 keywords = ["authentication", "bruteforce", "wordlist"]
-version = "1.2.0"
+version = "1.2.0-fix-set-cookies"
 authors = ["Simone Margaritelli <evilsocket@gmail.com>"]
 license = "GPL-3.0"
 edition = "2024"

--- a/pkg/brew/legba.rb
+++ b/pkg/brew/legba.rb
@@ -1,8 +1,8 @@
 
 class Legba < Formula
-    version '1.2.0'
+    version '1.2.0-fix-set-cookies'
     desc "Legba is a multiprotocol credentials bruteforcer / password sprayer and enumerator."
-    homepage "https://github.com/evilsocket/legba"
+    homepage "https://github.com/thibon/legba"
   
     if OS.mac?
         url "https://github.com/evilsocket/legba/releases/download/#{version}/legba-#{version}-apple-darwin-arm64.tar.gz"

--- a/src/plugins/http/mod.rs
+++ b/src/plugins/http/mod.rs
@@ -253,6 +253,11 @@ impl HTTP {
                 key, header_var_name
             );
 
+            // Skip set_cookie, handle separetely because can be null or multiple values
+            if header_var_name == "set_cookie" {
+                continue;
+            }
+
             if header_var_name == "content_type" {
                 content_type_set = true;
                 content_type = value.to_str().unwrap().to_owned();
@@ -262,6 +267,19 @@ impl HTTP {
                 .set_value(header_var_name, Value::from(value.to_str().unwrap()))
                 .map_err(|e| e.to_string())?;
         }
+
+        // Handle set_cookie separately because can contain multiplt value or not being set
+        let set_cookie_value = response
+            .headers()
+            .get_all("set-cookie")
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect::<Vec<&str>>()
+            .join("; ");
+
+        context
+            .set_value(String::from("set_cookie"), Value::from(set_cookie_value.as_str()))
+            .map_err(|e| e.to_string())?;
 
         // always set content_type
         if !content_type_set {


### PR DESCRIPTION
Fix #93 

When setting `--http-succes`s with something like `--http-success "set_cookie == ""` and set-cookie does not exist in the response, legs throw the following error:

> [ERROR] error evaluating success expression: Variable identifier is not bound to anything by context: "set_cookie".

This should fix the bug                                                                                  
