### PR TITLE
fix: add read/write timeouts to the RDP connection (remote hang)

### DIFF
--- a/src/plugins/rdp/mod.rs
+++ b/src/plugins/rdp/mod.rs
@@ -53,6 +53,15 @@ impl Plugin for RDP {
             .map_err(|e| e.to_string())?;
 
         let stream = TcpStream::connect_timeout(&address, timeout).map_err(|e| e.to_string())?;
+        // connect_timeout only bounds the connect; without these a malicious or silent RDP
+        // server would hang the operator's thread during the handshake reads in
+        // Connector::connect (blocking, synchronous socket).
+        stream
+            .set_read_timeout(Some(timeout))
+            .map_err(|e| e.to_string())?;
+        stream
+            .set_write_timeout(Some(timeout))
+            .map_err(|e| e.to_string())?;
 
         let mut rdp_connector = Connector::new()
             .screen(800, 600)


### PR DESCRIPTION
Same read-hang class as the Kerberos part of #99, for RDP.

`src/plugins/rdp/mod.rs`: the blocking `TcpStream` sets only `connect_timeout`, so a malicious or silent RDP server can hang the operator's thread indefinitely during the handshake reads inside `Connector::connect`. This sets read and write timeouts on the stream after connect.
