### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Once installed, your agent will know how to construct legba commands, write reci
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=evilsocket/legba&type=Timeline)](https://www.star-history.com/#evilsocket/legba&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=evilsocket/legba&type=Timeline)](https://star-history.dera.page/#evilsocket/legba&Timeline)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken because it relies on the stargazer API that GitHub no longer allows unrestricted access to. This change points it at a working alternative so the chart renders again.